### PR TITLE
NVM support

### DIFF
--- a/nvm/nvm.go
+++ b/nvm/nvm.go
@@ -1,0 +1,57 @@
+package nvm
+
+import (
+	"fmt"
+
+	"github.com/radar/setup/output"
+	"github.com/radar/setup/shell"
+)
+
+type NVM struct {
+	ExpectedVersion string
+}
+
+func Present() bool {
+	_, _, err := shell.Run("which nvm")
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+func CheckInstallation(expectedVersion string) (err error) {
+	nvm := NVM{
+		ExpectedVersion: expectedVersion,
+	}
+	err = nvm.checkVersionInstalled()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (nvm NVM) checkVersionInstalled() (err error) {
+	return shell.OptionalAction(
+		"nvm version " + nvm.ExpectedVersion,
+		nvm.correctVersionInstalled,
+		nvm.installExpectedVersion,
+	)
+}
+
+func (nvm NVM) correctVersionInstalled() (err error) {
+	return nil
+}
+
+func (nvm NVM) installExpectedVersion() (err error) {
+	output.Info(fmt.Sprintf("Installing Node (%s) with NVM...", nvm.ExpectedVersion))
+	installCmd := "nvm install " + nvm.ExpectedVersion
+	output.Info("$ " + installCmd)
+	stdout, stderr, err := shell.Run(installCmd)
+	fmt.Println(stdout.String())
+	fmt.Println(stderr.String())
+
+	return err
+
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1,0 +1,61 @@
+package shell
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Shell string
+const (
+	ZSH Shell = "zsh"
+	Bash Shell = "bash"
+	Unknown Shell = "unknown"
+)
+
+func Run(command string) (stdout bytes.Buffer, stderr bytes.Buffer, err error) {
+	var (
+		cmdName string
+		cmdArgs []string
+	)
+
+	switch detectShell() {
+	case ZSH:
+		cmdName = "zsh"
+		cmdArgs = []string{"-c", ". ~/.zshrc; " + command}
+	default:
+		err = errors.New("Unable to detect shell! ")
+		return
+	}
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+
+	return
+}
+
+type action func() error
+
+func OptionalAction(command string, success action, remedy action) (err error) {
+	_, _, err = Run(command)
+	if err != nil {
+		return remedy()
+	}
+
+	return success()
+}
+
+func detectShell() Shell {
+	shell := os.Getenv("SHELL")
+	if strings.Contains(shell, "zsh") {
+		return ZSH
+	} else if strings.Contains(shell, "bash") {
+		return Bash
+	}
+
+	return Unknown
+}

--- a/tool/install.go
+++ b/tool/install.go
@@ -6,11 +6,30 @@ import (
 	"strings"
 
 	"github.com/radar/setup/asdf"
+	"github.com/radar/setup/nvm"
 	"github.com/radar/setup/toolversions"
 	"github.com/radar/setup/output"
 	"github.com/radar/setup/runner"
 	"github.com/radar/setup/version"
 )
+
+type Source int
+
+const (
+	ASDF   Source = 0
+	NVM    Source = 1
+)
+
+func (source Source) String() string {
+	switch source {
+	case ASDF:
+		return "asdf"
+	case NVM:
+		return "NVM"
+	}
+
+	return ""
+}
 
 type Tool struct {
 	Name string
@@ -19,6 +38,7 @@ type Tool struct {
 	ExpectedVersion string
 	VersionCommand string
 	VersionRegexp string
+	Sources []Source
 }
 
 func (tool *Tool) SetExpectedVersion() error {
@@ -33,13 +53,33 @@ func (tool *Tool) SetExpectedVersion() error {
 	return nil
 }
 
-func (tool Tool) Install() error {
-	tool.findExecutable()
-	err := asdf.CheckInstallation(tool.PackageName, tool.ExpectedVersion)
+func (tool Tool) Install() (err error) {
+	err = tool.findExecutable()
+	installationSuccess := false
 
+	if err != nil {
+		for _, source := range tool.Sources {
+			err = tool.checkInstallation(source)
+			if err == nil {
+				installationSuccess = true
+				break
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+	} else {
+		installationSuccess = true
+	}
+
+	if (!installationSuccess) {
+		panic("Failed to install!")
+	}
 
 	actualVersion, err := tool.actualVersion()
 	if err != nil {
+		fmt.Println(actualVersion)
 		return err
 	}
 
@@ -66,15 +106,31 @@ func (tool Tool) findExecutable() error {
 	return nil
 }
 
+func (tool Tool) checkInstallation(source Source) (err error) {
+	switch source {
+	case ASDF:
+		err = asdf.CheckInstallation(tool.PackageName, tool.ExpectedVersion)
+	case NVM:
+		if nvm.Present() {
+			output.Found("NVM is installed. I will use that to install Node.")
+			err = nvm.CheckInstallation(tool.ExpectedVersion)
+		}
+	default:
+		panic("WHAT DO I DO WITH "+ source.String())
+	}
+
+	return err
+}
+
 func (tool Tool) actualVersion() (string, error) {
-	stdout, stderr, err := runner.Run(tool.VersionCommand)
+	stdout, stderr, err := shell.Run(tool.VersionCommand)
 	if err != nil {
 		return stderr, err
 	}
 
 	re := regexp.MustCompile(tool.VersionRegexp)
 	match := re.FindSubmatch([]byte(stdout))
-	rubyVersion := strings.TrimSpace(string(match[1]))
+	version := strings.TrimSpace(string(match[1]))
 
-	return rubyVersion, nil
+	return version, nil
 }


### PR DESCRIPTION
To manage Node versions, some people choose to use NVM.

This PR works towards supporting this in `setup`. The main difficulty is that we need to start a login shell to load the NVM shell scripts (probably from `~/.zshrc`). You also need to run `nvm use`, or have the auto-switching enabled. 

This brings about issues with `tool.ActualVersion()`:

* For ASDF: `node -v` is enough
* For NVM: `nvm use; node -v;` is what would be required.

The way that asdf works around this is that they have a shell script which is available in the $PATH:

```
$ which -a asdf
asdf () {
	local command
	command="$1"
	if [ "$#" -gt 0 ]
	then
		shift
	fi
	case "$command" in
		("shell") eval "$(asdf "sh-$command" "$@")" ;;
		(*) command asdf "$command" "$@" ;;
	esac
}
/usr/local/opt/asdf/bin/asdf
/usr/local/bin/asdf
```

So if ASDF hasn't been loaded through something like `~/.zshrc`, this shell script will load it, as proven by:

```
zsh -c "which -a asdf"
/usr/local/opt/asdf/bin/asdf
```

NVM though:

```
zsh -c "which -a nvm"
nvm not found
```

A potential solution to this would be to submit a patch to NVM which adds an `asdf`-esque `bin` script, which would then remove the requirement for running `nvm` within a login shell.

So I'm sidelining this work for now until I can come up with a good way of supporting NVM without having to load a login shell.


